### PR TITLE
Added random_crop, hf_split_name and renamed skip_arrow to no_cache for clarity as well as other fixes.

### DIFF
--- a/muse_maskgit_pytorch/dataset.py
+++ b/muse_maskgit_pytorch/dataset.py
@@ -85,16 +85,18 @@ class ImageTextDataset(ImageDataset):
         flip=True,
         center_crop=True,
         stream=False,
-        using_taming=False
+        using_taming=False,
+        random_crop=False,
     ):
         super().__init__(
             dataset,
             image_size=image_size,
             image_column=image_column,
             flip=flip,
-            center_crop=center_crop,
             stream=stream,
-            using_taming=using_taming
+            center_crop=center_crop,
+            using_taming=using_taming,
+            random_crop=random_crop,
         )
         self.caption_column: str = caption_column
         self.tokenizer: T5Tokenizer = tokenizer
@@ -192,7 +194,7 @@ class URLTextDataset(ImageDataset):
 
 
 class LocalTextImageDataset(Dataset):
-    def __init__(self, path, image_size, tokenizer, flip=True, center_crop=True, using_taming=False):
+    def __init__(self, path, image_size, tokenizer, flip=True, center_crop=True, using_taming=False, random_crop=False):
         super().__init__()
         self.tokenizer = tokenizer
         self.using_taming = using_taming
@@ -226,8 +228,10 @@ class LocalTextImageDataset(Dataset):
         ]
         if flip:
             transform_list.append(T.RandomHorizontalFlip())
-        if center_crop:
+        if center_crop and not random_crop:
             transform_list.append(T.CenterCrop(image_size))
+        if random_crop:
+            transform_list.append(T.RandomCrop(image_size, pad_if_needed=True))
         transform_list.append(T.ToTensor())
         self.transform = T.Compose(transform_list)
 

--- a/train_muse_maskgit.py
+++ b/train_muse_maskgit.py
@@ -70,6 +70,11 @@ parser.add_argument(
     help="Don't do center crop.",
 )
 parser.add_argument(
+        "--random_crop",
+        action="store_true",
+        help="Crop the images at random locations instead of cropping from the center.",
+    )
+parser.add_argument(
     "--no_flip",
     action="store_true",
     help="Don't flip image.",
@@ -698,7 +703,8 @@ def main():
                 tokenizer=transformer.tokenizer,
                 center_crop=False if args.no_center_crop else True,
                 flip=False if args.no_flip else True,
-                using_taming=False if not args.taming_model_path else True
+                using_taming=False if not args.taming_model_path else True,
+                random_crop=args.random_crop if args.random_crop else False,
             )
         elif args.link:
             if not args.dataset_name:

--- a/train_muse_maskgit.py
+++ b/train_muse_maskgit.py
@@ -407,6 +407,7 @@ class Arguments:
     logging_dir: str = "results/logs"
     vae_path: Optional[str] = None
     dataset_name: Optional[str] = None
+    hf_split_name:  Optional[str] = None
     streaming: bool = False
     train_data_dir: Optional[str] = None
     num_train_steps: int = -1

--- a/train_muse_vae.py
+++ b/train_muse_vae.py
@@ -139,6 +139,12 @@ parser.add_argument(
     help="Name of the huggingface dataset used.",
 )
 parser.add_argument(
+    "--hf_split_name",
+    type=str,
+    default="train",
+    help="Subset or split to use from the dataset when using a dataset form HuggingFace.",
+)
+parser.add_argument(
     "--streaming",
     action="store_true",
     help="Whether to stream the huggingface dataset",
@@ -256,9 +262,9 @@ parser.add_argument(
     help="The path to cache huggingface models",
 )
 parser.add_argument(
-    "--skip_arrow",
+    "--no_cache",
     action="store_true",
-    help="Whether to skip saving the dataset to Arrow files",
+    help="Do not save the dataset pyarrow cache/files to disk to save disk space and reduce the time it takes to launch the training.",
 )
 parser.add_argument(
     "--latest_checkpoint",
@@ -318,7 +324,7 @@ class Arguments:
     optimizer: str = "Lion"
     weight_decay: float = 0.0
     cache_path: Optional[str] = None
-    skip_arrow: bool = False
+    no_cache: bool = False
     latest_checkpoint: bool = False
     debug: bool = False
     config_path: Optional[str] = None
@@ -376,7 +382,7 @@ def main():
             image_column=args.image_column,
             caption_column=args.caption_column,
             save_path=args.dataset_save_path,
-            save=not args.skip_arrow
+            save=not args.no_cache
         )
     elif args.dataset_name:
         if args.cache_path:
@@ -392,9 +398,9 @@ def main():
                 print("Dataset doesn't support streaming, disabling streaming")
                 args.streaming = False
                 if args.cache_path:
-                    dataset = load_dataset(args.dataset_name, cache_dir=args.cache_path)["train"]
+                    dataset = load_dataset(args.dataset_name, cache_dir=args.cache_path)[args.hf_split_name]
                 else:
-                    dataset = load_dataset(args.dataset_name)["train"]
+                    dataset = load_dataset(args.dataset_name)[args.hf_split_name]
 
     if args.resume_path is not None:
         load = True
@@ -476,7 +482,7 @@ def main():
             accelerator=accelerator,
 
         )
-        
+
         current_step = 0
 
     dataset = ImageDataset(


### PR DESCRIPTION
- Added hf_split_name to set the split or subset to use for huggingface datasets.
- Renamed `skip_arrow` to `no_cache.`
- Added a check so when the cache exist but the folder where the original data for the dataset is modified the cache is removed and recreated, this will help keeping up the cache up to date with the dataset directory.
- Added random_crop argument for the maskgit training.
