### PR TITLE
actions: fix pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
 
       - name: Install package
         id: install-package


### PR DESCRIPTION
I forgot that setup-python's pip cache mode requires a requirements.txt or pyproject.toml/setup.cfg to work properly (setup.py won't do it)

Fortunately we don't really need it, so... removed.