### PR TITLE
Changed the pretrained "pretrained=True" to be "weights=torchvision.models.VGG16_Weights.DEFAULT" so it is compatible with latest version of torchvision and also so we always get the latest version of the weights.

### DIFF
--- a/muse_maskgit_pytorch/vqgan_vae.py
+++ b/muse_maskgit_pytorch/vqgan_vae.py
@@ -407,7 +407,7 @@ class VQGanVAE(nn.Module):
         if exists(self._vgg):
             return self._vgg
 
-        vgg = torchvision.models.vgg16(pretrained=True)
+        vgg = torchvision.models.vgg16(weights=torchvision.models.VGG16_Weights.DEFAULT)
         vgg.classifier = nn.Sequential(*vgg.classifier[:-2])
         self._vgg = vgg.to(self.device)
         return self._vgg


### PR DESCRIPTION
This should work but if one of you can test it before we merge it to the dev branch it would be nice, that way we are 100% sure it doesn't break anything and works for everyone else as well.