### PR TITLE
Fixed missing wandb dependency.

### DIFF
--- a/infer_maskgit.py
+++ b/infer_maskgit.py
@@ -1,6 +1,3 @@
-from torchvision.utils import save_image
-import os, glob, re, torch
-from datetime import datetime
 import argparse
 import glob
 import os
@@ -433,16 +430,16 @@ def main():
         # ready your training text and images
         images = maskgit.generate(
             texts=texts,
-            #cond_images=F.interpolate(torch.randn(1, 3, 512, 512).to('cpu' if args.cpu else accelerator.device if args.gpu == 0 else f"cuda:{args.gpu}"), 256),
-            cond_scale = args.cond_scale, # conditioning scale for classifier free guidance
-            timesteps = args.timesteps,
-            #fmap_size=None,
-            #temperature=1.0,
-            #topk_filter_thres=0.9,
-            #can_remask_prev_masked=False,
-            #force_not_use_token_critic=False,
-            #critic_noise_scale=1,
-            )
+            # cond_images=F.interpolate(torch.randn(1, 3, 512, 512).to('cpu' if args.cpu else accelerator.device if args.gpu == 0 else f"cuda:{args.gpu}"), 256),
+            cond_scale=args.cond_scale,  # conditioning scale for classifier free guidance
+            timesteps=args.timesteps,
+            # fmap_size=None,
+            # temperature=1.0,
+            # topk_filter_thres=0.9,
+            # can_remask_prev_masked=False,
+            # force_not_use_token_critic=False,
+            # critic_noise_scale=1,
+        )
 
         # print(images.shape) # (3, 3, 256, 256)
 

--- a/infer_vae.py
+++ b/infer_vae.py
@@ -584,7 +584,7 @@ def main():
 
                     else:
                         if "out of memory" not in str(e):
-                            print(e)
+                            print(f"\n{e}")
                         else:
                             print(f"Skipping image {i} after {retries} retries due to out of memory error")
                         break  # Exit the retry loop after too many retries

--- a/muse_maskgit_pytorch/dataset.py
+++ b/muse_maskgit_pytorch/dataset.py
@@ -77,11 +77,28 @@ class ImageDataset(Dataset):
             raise AssertionError("Streaming doesnt support grabbing dataset length")
 
     def __getitem__(self, index):
-        image = self.dataset[index][self.image_column]
-        if self.using_taming:
-            return self.transform(image) - 0.5
-        else:
-            return self.transform(image)
+        try:
+            image = self.dataset[index][self.image_column]
+            if self.using_taming:
+                return self.transform(image) - 0.5
+            else:
+                return self.transform(image)
+        except TypeError:
+            try:
+                image = pImage.open(BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content))
+            except ConnectionError:
+                try:
+                    print("Image request failure, attempting next image")
+                    index += 1
+
+                    image = pImage.open(BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content))
+                except ConnectionError:
+                    raise ConnectionError("Unable to request image from the Dataset")
+
+            if self.using_taming:
+                return self.transform(image) - 0.5
+            else:
+                return self.transform(image)
 
 
 class ImageTextDataset(ImageDataset):

--- a/muse_maskgit_pytorch/dataset.py
+++ b/muse_maskgit_pytorch/dataset.py
@@ -85,13 +85,17 @@ class ImageDataset(Dataset):
                 return self.transform(image)
         except TypeError:
             try:
-                image = pImage.open(BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content))
+                image = pImage.open(
+                    BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content)
+                )
             except ConnectionError:
                 try:
                     print("Image request failure, attempting next image")
                     index += 1
 
-                    image = pImage.open(BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content))
+                    image = pImage.open(
+                        BytesIO(requests.get(self.dataset[index][self.image_column], timeout=30).content)
+                    )
                 except ConnectionError:
                     raise ConnectionError("Unable to request image from the Dataset")
 

--- a/muse_maskgit_pytorch/muse_maskgit_pytorch.py
+++ b/muse_maskgit_pytorch/muse_maskgit_pytorch.py
@@ -553,7 +553,7 @@ class MaskGit(nn.Module):
                 reversed(range(timesteps)),
             ),
             total=timesteps,
-            dynamic_ncols=True
+            dynamic_ncols=True,
         ):
             rand_mask_prob = self.noise_schedule(timestep)
             num_token_masked = max(int((rand_mask_prob * seq_len).item()), 1)

--- a/muse_maskgit_pytorch/vqgan_vae.py
+++ b/muse_maskgit_pytorch/vqgan_vae.py
@@ -92,7 +92,8 @@ def groupby_prefix_and_trim(prefix, d):
 def log(t, eps=1e-10):
     return torch.log(t + eps)
 
-def gradient_penalty(images, output, weight = 10):
+
+def gradient_penalty(images, output, weight=10):
     batch_size = images.shape[0]
 
     gradients = torch_grad(
@@ -164,22 +165,24 @@ class Discriminator(nn.Module):
         self.layers = MList(
             [
                 nn.Sequential(
-                    nn.Conv2d(channels, dims[0], init_kernel_size, padding = init_kernel_size // 2),
+                    nn.Conv2d(channels, dims[0], init_kernel_size, padding=init_kernel_size // 2),
                     leaky_relu(),
                 )
             ]
         )
 
         for dim_in, dim_out in dim_pairs:
-            self.layers.append(nn.Sequential(
-                nn.Conv2d(dim_in, dim_out, 4, stride = 2, padding = 1),
-                nn.GroupNorm(groups, dim_out),
-                leaky_relu(),
-            ))
+            self.layers.append(
+                nn.Sequential(
+                    nn.Conv2d(dim_in, dim_out, 4, stride=2, padding=1),
+                    nn.GroupNorm(groups, dim_out),
+                    leaky_relu(),
+                )
+            )
 
         dim = dims[-1]
         # return 5 x 5, for PatchGAN-esque training
-        self.to_logits = nn.Sequential(nn.Conv2d(dim, dim, 1),leaky_relu(),nn.Conv2d(dim, 1, 4))
+        self.to_logits = nn.Sequential(nn.Conv2d(dim, dim, 1), leaky_relu(), nn.Conv2d(dim, 1, 4))
 
     def forward(self, x):
         for net in self.layers:

--- a/muse_maskgit_pytorch/vqgan_vae.py
+++ b/muse_maskgit_pytorch/vqgan_vae.py
@@ -92,8 +92,9 @@ def groupby_prefix_and_trim(prefix, d):
 def log(t, eps=1e-10):
     return torch.log(t + eps)
 
+def gradient_penalty(images, output, weight = 10):
+    batch_size = images.shape[0]
 
-def gradient_penalty(images, output, weight=10):
     gradients = torch_grad(
         outputs=output,
         inputs=images,
@@ -163,24 +164,22 @@ class Discriminator(nn.Module):
         self.layers = MList(
             [
                 nn.Sequential(
-                    nn.Conv2d(channels, dims[0], init_kernel_size, padding=init_kernel_size // 2),
+                    nn.Conv2d(channels, dims[0], init_kernel_size, padding = init_kernel_size // 2),
                     leaky_relu(),
                 )
             ]
         )
 
         for dim_in, dim_out in dim_pairs:
-            self.layers.append(
-                nn.Sequential(
-                    nn.Conv2d(dim_in, dim_out, 4, stride=2, padding=1),
-                    nn.GroupNorm(groups, dim_out),
-                    leaky_relu(),
-                )
-            )
+            self.layers.append(nn.Sequential(
+                nn.Conv2d(dim_in, dim_out, 4, stride = 2, padding = 1),
+                nn.GroupNorm(groups, dim_out),
+                leaky_relu(),
+            ))
 
         dim = dims[-1]
         # return 5 x 5, for PatchGAN-esque training
-        self.to_logits = nn.Sequential(nn.Conv2d(dim, dim, 1), leaky_relu(), nn.Conv2d(dim, 1, 4))
+        self.to_logits = nn.Sequential(nn.Conv2d(dim, dim, 1),leaky_relu(),nn.Conv2d(dim, 1, 4))
 
     def forward(self, x):
         for net in self.layers:
@@ -476,7 +475,7 @@ class VQGanVAE(nn.Module):
         return_discr_loss=False,
         return_recons=False,
         add_gradient_penalty=True,
-        relu_loss=True,
+        relu_loss=False,
     ):
         batch, channels, height, width, device = *img.shape, img.device
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "lion-pytorch",
         "omegaconf",
         "xformers>=0.0.20",
+        "wandb",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
- Fixed HF datasets not loading properly since we were not actually requesting the image from the url when the dataset contained a column with urls instead of the images themselves.
- The relu_loss on the vqgan_vae.py has been set back to False since this is the intended way to calculate the loss. The code for turning it on again is still there in case we need to do some more tests with the ReLU loss calculation.