### PR TITLE
The VAE validation images are now saved as individual image pairs rather than a single grid of images.

### DIFF
--- a/infer_maskgit.py
+++ b/infer_maskgit.py
@@ -446,7 +446,7 @@ def main():
         now = datetime.now().strftime("%m-%d-%Y_%H-%M-%S.%f")
 
         # save image to disk
-        save_path = str(f"{args.results_dir}/outputs/validation/maskgit/{now}.png")
+        save_path = str(f"{args.results_dir}/outputs/validation/maskgit/{now}-{current_step}.png")
         os.makedirs(str(f"{args.results_dir}/outputs/validation/maskgit/"), exist_ok=True)
 
         save_image(images, save_path)

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -201,7 +201,6 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
         # else save a grid of images
 
         for i in range(valid_data.shape[0]):
-
             # Get sample and reconstruction
             sample = valid_data[i]
             recon = recons[i]

--- a/muse_maskgit_pytorch/vqgan_vae.py
+++ b/muse_maskgit_pytorch/vqgan_vae.py
@@ -439,7 +439,7 @@ class VQGanVAE(nn.Module):
 
     @remove_vgg
     def load_state_dict(self, *args, **kwargs):
-        return super().load_state_dict(*args, **kwargs, strict=False)
+        return super().load_state_dict(*args, **kwargs)
 
     def save(self, path):
         if self.accelerator is not None:


### PR DESCRIPTION
- Reverting the change to load_state_dict on the VQGanVAE class since it was causing issues with the whole training crashing after a while, we need a better solution to this.
- Append the checkpoint number of steps to the images generated by Maskgit so we can better remember what checkpoint was used for making it when doing tests.
